### PR TITLE
Remove reliance on `Pkg.Compress` for Julia 1.4+

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -198,7 +198,11 @@ function compress_versions(pool::Vector{VersionNumber}, subset)
     compress_versions(pool, filter(in(subset), pool))
 end
 
-import Pkg.Compress.load_versions
+function load_versions(path::String)
+    versions_file = joinpath(dirname(path), "Versions.toml")
+    versions_dict = TOML.parsefile(versions_file)
+    return sort!([VersionNumber(v) for v in keys(versions_dict)])
+end
 
 function compress(path::AbstractString, uncompressed::Dict,
     versions::Vector{VersionNumber} = load_versions(path))


### PR DESCRIPTION
`Pkg.Compress` doesn't exist in Julia 1.4+, so let's remove this and tag a version so that RegistryTools works on 1.4+