### PR TITLE
Opt out of errors

### DIFF
--- a/src/RegistryTools.jl
+++ b/src/RegistryTools.jl
@@ -2,6 +2,7 @@ module RegistryTools
 
 export RegBranch
 export register
+export check_and_update_registry_files
 
 using AutoHashEquals
 using LibGit2

--- a/src/register.jl
+++ b/src/register.jl
@@ -588,7 +588,7 @@ function register(
     regbr = RegBranch(pkg, branch)
 
     # status object
-    status = ReturnStatus(checks_triggering_errors)
+    status = ReturnStatus(checks_triggering_error)
 
     # get up-to-date clone of registry
     @debug("get up-to-date clone of registry")

--- a/src/types.jl
+++ b/src/types.jl
@@ -148,13 +148,13 @@ function TOML.print(io::IO, reg::RegistryData)
     nothing
 end
 
-function package_relpath(reg::RegistryData, pkg::Pkg.Types.Project)
+function package_relpath(pkg::Pkg.Types.Project)
     joinpath("$(uppercase(pkg.name[1]))", pkg.name)
 end
 
 function Base.push!(reg::RegistryData, pkg::Pkg.Types.Project)
     reg.packages[string(pkg.uuid)] = Dict(
-        "name" => pkg.name, "path" => package_relpath(reg, pkg)
+        "name" => pkg.name, "path" => package_relpath(pkg)
     )
     reg
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -148,8 +148,10 @@ function TOML.print(io::IO, reg::RegistryData)
     nothing
 end
 
+# Not using `joinpath` here since we don't want backslashes in
+# Registry.toml when running on Windows.
 function package_relpath(pkg::Pkg.Types.Project)
-    joinpath("$(uppercase(pkg.name[1]))", pkg.name)
+    string(uppercase(pkg.name[1]), "/", pkg.name)
 end
 
 function Base.push!(reg::RegistryData, pkg::Pkg.Types.Project)

--- a/test/project_files/Dep1.toml
+++ b/test/project_files/Dep1.toml
@@ -1,0 +1,9 @@
+name = "Dep"
+uuid = "49c7135d-e2b1-4bed-912f-5371fe4924fa"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"

--- a/test/project_files/Example1.toml
+++ b/test/project_files/Example1.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example10.toml
+++ b/test/project_files/Example10.toml
@@ -1,0 +1,16 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "bd67dec4-8562-47c8-bf6d-f3713b93fe31"
+Example = "d7508571-2240-4c50-b21c-240e414cc6d2"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example11.toml
+++ b/test/project_files/Example11.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+uuids = "bd67dec4-8562-47c8-bf6d-f3713b93fe31"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example12.toml
+++ b/test/project_files/Example12.toml
@@ -1,0 +1,16 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Dep = "49c7135d-e2b1-4bed-912f-5371fe4924fa"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example13.toml
+++ b/test/project_files/Example13.toml
@@ -1,0 +1,16 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+dep = "49c7135d-e2b1-4bed-912f-5371fe4924fa"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example14.toml
+++ b/test/project_files/Example14.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "0.6,0.7,1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example15.toml
+++ b/test/project_files/Example15.toml
@@ -1,0 +1,16 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+Dep = "1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example16.toml
+++ b/test/project_files/Example16.toml
@@ -1,0 +1,17 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Dep = "49c7135d-e2b1-4bed-912f-5371fe4924fa"
+
+[compat]
+julia = "1.1"
+Dep = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example17.toml
+++ b/test/project_files/Example17.toml
@@ -1,0 +1,17 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+Dep = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Dep = "49c7135d-e2b1-4bed-912f-5371fe4924fa"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example18.toml
+++ b/test/project_files/Example18.toml
@@ -1,0 +1,16 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.1.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+Dep = "49c7135d-e2b1-4bed-912f-5371fe4924fa"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example2.toml
+++ b/test/project_files/Example2.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.1"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example3.toml
+++ b/test/project_files/Example3.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.1.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example4.toml
+++ b/test/project_files/Example4.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "2.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example5.toml
+++ b/test/project_files/Example5.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "0.0.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example6.toml
+++ b/test/project_files/Example6.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.5.3"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example7.toml
+++ b/test/project_files/Example7.toml
@@ -1,0 +1,15 @@
+name = "Exempel"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.1.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example8.toml
+++ b/test/project_files/Example8.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "7ba5e0ae-323a-4335-8691-1c2244bf2e2b"
+version = "1.1.0"
+
+[deps]
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/project_files/Example9.toml
+++ b/test/project_files/Example9.toml
@@ -1,0 +1,15 @@
+name = "Example"
+uuid = "d7508571-2240-4c50-b21c-240e414cc6d2"
+version = "1.0.0"
+
+[deps]
+UUIDs = "bd67dec4-8562-47c8-bf6d-f3713b93fe31"
+
+[compat]
+julia = "1.1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -125,7 +125,7 @@ end
         @test length(registry_data.packages) == 1
         @test haskey(registry_data.packages, string(example.uuid))
         @test registry_data.packages[string(example.uuid)]["name"] == "Example"
-        @test registry_data.packages[string(example.uuid)]["path"] == joinpath("E", "Example")
+        @test registry_data.packages[string(example.uuid)]["path"] == "E/Example"
     end
 end
 

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -437,6 +437,31 @@ end
                           kind = "New package",
                           labels = String["new package"]))
 
+            # Compat for non-dependency. On Julia 1.2 and later this
+            # gives an error already in `read_project`, so only run it
+            # on Julia 1.1.
+            (project_files = ["Example15"],
+             skip_for_newer_julia = true,
+             status = Symbol[:new_package, :new_package_label,
+                             :invalid_compat],
+             regbranch = (error = true, warning = false,
+                          kind = "New package",
+                          labels = String["new package"]))
+
+            # Compat entry for package in deps.
+            (project_files = ["Dep1", "Example16"],
+             status = Symbol[:new_package, :new_package_label],
+             regbranch = (error = false, warning = false,
+                          kind = "New package",
+                          labels = String["new package"]))
+
+            # Compat entry for package in extras.
+            (project_files = ["Dep1", "Example17"],
+             status = Symbol[:new_package, :new_package_label],
+             regbranch = (error = false, warning = false,
+                          kind = "New package",
+                          labels = String["new package"]))
+
             # Change package repo.
             (project_files = ["Example1", "Example2"],
              modify_package_repo = "Example2",
@@ -454,6 +479,9 @@ end
         registry_deps_paths = String[]
         tree_hash = repeat("0", 40)
         for test_data in registry_update_tests
+            if haskey(test_data, :skip_for_newer_julia) && VERSION >= v"1.2"
+                continue
+            end
             # Clean up from previous iteration.
             isdir(registry_path) && rm(registry_path, recursive = true)
             mkpath(registry_path)

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -263,7 +263,7 @@ end
         pkg = Project(version = v"1.0.0", deps = deps)
         update_versions_file(pkg, joinpath(temp_dir, "Versions.toml"),
                              Dict{String, Any}(), repeat("0", 40))
-        update_deps_file(pkg, temp_dir)
+        update_deps_file(pkg, temp_dir, VersionNumber[])
         deps_file = joinpath(temp_dir, "Deps.toml")
         @test isfile(deps_file)
         @test read(deps_file, String) == """
@@ -280,7 +280,7 @@ end
         pkg = Project(version = v"1.0.0", compat = compat)
         update_versions_file(pkg, joinpath(temp_dir, "Versions.toml"),
                              Dict{String, Any}(), repeat("0", 40))
-        update_compat_file(pkg, temp_dir)
+        update_compat_file(pkg, temp_dir, VersionNumber[])
         compat_file = joinpath(temp_dir, "Compat.toml")
         @test isfile(compat_file)
         @test read(compat_file, String) == """


### PR DESCRIPTION
Continuation of #13 and #15. The third commit adds a mechanism to choose which checks should trigger errors as suggested in #14. It also redesigns parts of #13.

Update: A fourth commit splits off a new function for the parts of `register` that check and update the registry files. This makes it more useful for other users than Registrator and allows testing of a much larger part of the code, which is also done in the commit.

After another couple of commits, test coverage is up above 95% and I'm feeling confident that the code is in good shape.