### PR TITLE
Split out check of package URL from find_package_in_registry.

### DIFF
--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -246,7 +246,7 @@ end
                            "uuid" => package_uuid))
         status = ReturnStatus()
 
-        find_package_in_registry(pkg, "", registry_file, registry_path,
+        find_package_in_registry(pkg, registry_file, registry_path,
                                  registry_data, status)
         print(read(registry_file, String))
         @test read(registry_file, String) == """
@@ -327,8 +327,7 @@ end
 
 @testset "registry updates" begin
     import RegistryTools: RegistryData, ReturnStatus, haserror,
-                          write_registry, find_package_in_registry,
-                          check_and_update_registry_files,
+                          write_registry, check_and_update_registry_files,
                           RegBranch, set_metadata!
     import Pkg.Types: read_project
     registry_update_tests =


### PR DESCRIPTION
The check whether the repo URL is unchanged has nothing to do with *finding* the package in the registry and is therefore moved to a new function.