### PR TITLE
New function find_registered_version.

### DIFF
--- a/src/RegistryTools.jl
+++ b/src/RegistryTools.jl
@@ -3,6 +3,7 @@ module RegistryTools
 export RegBranch
 export register
 export check_and_update_registry_files
+export find_registered_version
 
 using AutoHashEquals
 using LibGit2

--- a/src/register.jl
+++ b/src/register.jl
@@ -685,3 +685,28 @@ end
 register(regp::RegisterParams) = register(regp.package_repo, regp.pkg, regp.tree_sha;
                                           registry=regp.registry, registry_deps=regp.registry_deps,
                                           push=regp.push, gitconfig=regp.gitconfig)
+
+"""
+    find_registered_version(pkg, registry_path)
+
+If the package and version specified by `pkg` exists in the registry
+at `registry_path`, return its tree hash. Otherwise return the empty
+string.
+"""
+function find_registered_version(pkg::Pkg.Types.Project,
+                                 registry_path::AbstractString)
+    registry_file = joinpath(registry_path, "Registry.toml")
+    registry_data = parse_registry(registry_file)
+    # Cannot use find_package_in_registry since it may add paths in
+    # the registry.
+    if !haskey(registry_data.packages, string(pkg.uuid))
+        return ""
+    end
+    package_data = registry_data.packages[string(pkg.uuid)]
+    package_path = joinpath(registry_path, package_data["path"])
+    _, versions_data = get_versions_file(package_path)
+    if !haskey(versions_data, string(pkg.version))
+        return ""
+    end
+    return versions_data[string(pkg.version)]["git-tree-sha1"]
+end

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -614,5 +614,33 @@ end
     end
 end
 
+@testset "find_registered_version" begin
+    mktempdir(@__DIR__) do temp_dir
+        registry_path = temp_dir
+
+        # Create an empty registry.
+        create_empty_registry(registry_path, "Registry1",
+                              "7e1d4fce-5fe6-405e-8bac-078d4138e9a2")
+
+        # Add a package.
+        projects_path = joinpath(@__DIR__, "project_files")
+        project_file = joinpath(projects_path, "Example1.toml")
+        pkg = read_project(project_file)
+        @test find_registered_version(pkg, registry_path) == ""
+
+        package_repo = string("http://example.com/$(pkg.name).git")
+        tree_hash = "7dd821daaae58ddf9fee53e00aa1aab33794d130"
+        registry_deps_paths = String[]
+        status = ReturnStatus()
+        check_and_update_registry_files(pkg, package_repo, tree_hash,
+                                        registry_path,
+                                        registry_deps_paths, status)
+
+        @test find_registered_version(pkg, registry_path) == tree_hash
+        project_file = joinpath(projects_path, "Example2.toml")
+        pkg = read_project(project_file)
+        @test find_registered_version(pkg, registry_path) == ""
+    end
+end
 
 end


### PR DESCRIPTION
New functionality that I want to use in the LocalRegistry package. This can be used to detect a mistaken re-registration of the same version with the same tree_hash, which in an interactive setting can be signaled more friendly than with an error. It is also useful to support CI-based registration workflows, which could for example do a registration whenever a not previously registered version is checked in on master and passes its tests.
