### PR TITLE
RFC: Make registering an older version than any existing allowed by default

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -60,7 +60,6 @@ const mandatory_errors = [:version_exists,
 # These are considered errors by Registrator and are default for the
 # `register` function. The caller can override this selection.
 const registrator_errors = [:version_zero,
-                            :version_less_than_all_existing,
                             :change_package_url,
                             :dependency_not_found,
                             :julia_before_07_in_compat,


### PR DESCRIPTION
#16 makes it possible for the caller of `register` to opt out of a number of errors for various checks being done on the package, including the #6 issue of registering an older version of a package than any that has been previously registered.

This PR changes that particular error to be an opt-in instead of an opt-out. Note that this is arguably a breaking change.

The other errors that are currently opt-out but could be changed to opt-in are:
* Registering version 0.0.0.
* Change the repo URL of a package.
* A dependency could not be found in any of the registries provided to `register` for this check.
* The package declares compatibility with an older Julia version than 0.7.
* A package is listed in `compat` but neither in `deps`, nor `extras`. Note, for Julia >= 1.2 this is an error at the Pkg level.
* "Unexpected registration error". This happens if a runtime error is caught while running `register`. Not really sure why I listed it as opt-out instead of mandatory in the first place.

It should be pointed out that this code is not responsible for auto-merge policies, only for creation of registration requests.
