### PR TITLE
Support registration of packages in subdirectories of git repositories.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.3.4"
+version = "1.4.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"


### PR DESCRIPTION
Write subdirectory information in `Package.toml` as discussed in #30, using the format:
```
name = "RegistryTools"
uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
repo = "https://github.com/JuliaRegistries/RegistryTools.jl.git"
subdir = "path/to/package"
```