### PR TITLE
add subdir field to RegisterParams

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/register.jl
+++ b/src/register.jl
@@ -707,6 +707,7 @@ struct RegisterParams
     tree_sha::AbstractString
     registry::AbstractString
     registry_deps::Vector{<:AbstractString}
+    subdir::AbstractString
     push::Bool
     gitconfig::Dict
 
@@ -715,17 +716,18 @@ struct RegisterParams
                             tree_sha::AbstractString;
                             registry::AbstractString=DEFAULT_REGISTRY_URL,
                             registry_deps::Vector{<:AbstractString}=[],
+                            subdir::AbstractString="",
                             push::Bool=false,
                             gitconfig::Dict=Dict())
         new(package_repo, pkg, tree_sha,
-            registry, registry_deps,
+            registry, registry_deps, subdir,
             push, gitconfig)
     end
 end
 
 register(regp::RegisterParams) = register(regp.package_repo, regp.pkg, regp.tree_sha;
                                           registry=regp.registry, registry_deps=regp.registry_deps,
-                                          push=regp.push, gitconfig=regp.gitconfig)
+                                          subdir=regp.subdir, push=regp.push, gitconfig=regp.gitconfig)
 
 """
     find_registered_version(pkg, registry_path)


### PR DESCRIPTION
This PR adds the subdir field to RegisterParams in anticipation of adding in subdirectory registration functionality to Registrator.jl. I bumped the minor version as the new field is not breaking anything existing, but is a new "feature"