### PR TITLE
Temporary fix: change "github" to "GitHub"

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -624,6 +624,7 @@ function register(
     if !isempty(package_repo)
         package_repo = GitTools.normalize_url(package_repo)
     end
+    package_repo = replace(package_repo, "github" => "GitHub")
 
     # return object
     regbr = RegBranch(pkg, branch)

--- a/src/register.jl
+++ b/src/register.jl
@@ -624,7 +624,7 @@ function register(
     if !isempty(package_repo)
         package_repo = GitTools.normalize_url(package_repo)
     end
-    package_repo = replace(package_repo, "github" => "GitHub")
+    package_repo = replace(package_repo, r"^https?://github\.com/"i => "https://GitHub.com/")
 
     # return object
     regbr = RegBranch(pkg, branch)


### PR DESCRIPTION
Not sure if this is sufficient.

@StefanKarpinski 