### PR TITLE
Adding optional arguments to include non-default registry branches (e.g. "main")

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -617,8 +617,7 @@ function register(
     force_reset::Bool = true,
     branch::String = registration_branch(pkg),
     cache::RegistryCache=REGISTRY_CACHE,
-    gitconfig::Dict = Dict(),
-    default_registry_branch::AbstractString="master"
+    gitconfig::Dict = Dict()
 )
     # get info from package registry
     @debug("get info from package registry")
@@ -649,6 +648,7 @@ function register(
         # branch registry repo
         @debug("branch registry repo")
         git = gitcmd(registry_path, gitconfig)
+        default_registry_branch = split(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`), '/')[end]
         run(pipeline(`$git checkout -f $default_registry_branch`; stdout=devnull))
         if branch != default_registry_branch
             run(pipeline(`$git branch -f $branch`; stdout=devnull))

--- a/src/register.jl
+++ b/src/register.jl
@@ -617,7 +617,8 @@ function register(
     force_reset::Bool = true,
     branch::String = registration_branch(pkg),
     cache::RegistryCache=REGISTRY_CACHE,
-    gitconfig::Dict = Dict()
+    gitconfig::Dict = Dict(),
+    default_registry_branch::AbstractString="master"
 )
     # get info from package registry
     @debug("get info from package registry")
@@ -648,8 +649,8 @@ function register(
         # branch registry repo
         @debug("branch registry repo")
         git = gitcmd(registry_path, gitconfig)
-        run(pipeline(`$git checkout -f master`; stdout=devnull))
-        if branch != "master"
+        run(pipeline(`$git checkout -f $default_registry_branch`; stdout=devnull))
+        if branch != default_registry_branch
             run(pipeline(`$git branch -f $branch`; stdout=devnull))
             run(pipeline(`$git checkout -f $branch`; stdout=devnull))
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -32,22 +32,23 @@ function get_registry(
     gitconfig::Dict=Dict(),
     cache::RegistryCache=REGISTRY_CACHE,
     force_reset::Bool=true,
+    default_registry_branch::AbstractString="master"
 )
     if haskey(cache.registries, registry_url)
         registry_path = path(cache, registry_url)
 
         if !ispath(registry_path)
             mkpath(path(cache))
-            run(`git clone $registry_url $registry_path --branch=master`)
+            run(`git clone $registry_url $registry_path --branch=$default_registry_branch`)
         else
             # this is really annoying/impossible to do with LibGit2
             git = gitcmd(registry_path, gitconfig)
             run(`$git config remote.origin.url $registry_url`)
-            run(`$git checkout -q -f master`)
+            run(`$git checkout -q -f $default_registry_branch`)
             # uses config because git versions <2.17.0 did not have the -P option
-            run(`$git -c fetch.pruneTags fetch -q origin master`)
+            run(`$git -c fetch.pruneTags fetch -q origin $default_registry_branch`)
             if force_reset
-                run(`$git reset -q --hard origin/master`)
+                run(`$git reset -q --hard origin/$default_registry_branch`)
             end
         end
     else

--- a/src/types.jl
+++ b/src/types.jl
@@ -32,11 +32,10 @@ function get_registry(
     gitconfig::Dict=Dict(),
     cache::RegistryCache=REGISTRY_CACHE,
     force_reset::Bool=true,
-    default_registry_branch::AbstractString="master"
 )
     if haskey(cache.registries, registry_url)
         registry_path = path(cache, registry_url)
-
+default_registry_branch = split(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`), '/')[end]
         if !ispath(registry_path)
             mkpath(path(cache))
             run(`git clone $registry_url $registry_path --branch=$default_registry_branch`)


### PR DESCRIPTION
Added optional argument `default_registry_branch` with default value "master" to allow for non-standard default registry names (e.g. "main" or "trunk").

Ran tests with `pkg> test` and everything passes! ✔️ 

I'm not as familiar with Github as I am with Gitlab, but I imagine Github has the concept of a "default branch" for every repo . I imagine an even better solution than this would be to dynamically select the "default branch" of whatever registry you're working with instead of passing in a static string (or worse like we had here - a hard-coded "master").

