### PR TITLE
use registries default branch rather than master

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -649,8 +649,9 @@ function register(
         # branch registry repo
         @debug("branch registry repo")
         git = gitcmd(registry_path, gitconfig)
-        run(pipeline(`$git checkout -f master`; stdout=devnull))
-        if branch != "master"
+        default_branch = split(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`), '/')[end]
+        run(pipeline(`$git checkout -f $default_branch`; stdout=devnull))
+        if branch != default_branch
             run(pipeline(`$git branch -f $branch`; stdout=devnull))
             run(pipeline(`$git checkout -f $branch`; stdout=devnull))
         end

--- a/src/register.jl
+++ b/src/register.jl
@@ -649,7 +649,7 @@ function register(
         # branch registry repo
         @debug("branch registry repo")
         git = gitcmd(registry_path, gitconfig)
-        default_branch = split(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`), '/')[end]
+        default_branch = splitpath(String(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`)))[end]
         run(pipeline(`$git checkout -f $default_branch`; stdout=devnull))
         if branch != default_branch
             run(pipeline(`$git branch -f $branch`; stdout=devnull))

--- a/src/register.jl
+++ b/src/register.jl
@@ -637,6 +637,7 @@ function register(
     registry = GitTools.normalize_url(registry)
     registry_repo = get_registry(registry; gitconfig=gitconfig, force_reset=force_reset, cache=cache)
     registry_path = LibGit2.path(registry_repo)
+    registry_default_branch = LibGit2.branch(registry_repo)
 
     isempty(registry_deps) || @debug("get up-to-date clones of registry dependencies")
     registry_deps_paths = map(registry_deps) do registry
@@ -649,9 +650,8 @@ function register(
         # branch registry repo
         @debug("branch registry repo")
         git = gitcmd(registry_path, gitconfig)
-        default_branch = splitpath(String(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`)))[end]
-        run(pipeline(`$git checkout -f $default_branch`; stdout=devnull))
-        if branch != default_branch
+        run(pipeline(`$git checkout -f $registry_default_branch`; stdout=devnull))
+        if branch != registry_default_branch
             run(pipeline(`$git branch -f $branch`; stdout=devnull))
             run(pipeline(`$git checkout -f $branch`; stdout=devnull))
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,7 +35,7 @@ function get_registry(
 )
     if haskey(cache.registries, registry_url)
         registry_path = path(cache, registry_url)
-        default_branch = split(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`), '/')[end]
+        default_branch = splitpath(String(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`)))[end]
 
         if !ispath(registry_path)
             mkpath(path(cache))

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,7 +39,7 @@ function get_registry(
 
         if !ispath(registry_path)
             mkpath(path(cache))
-            run(`git clone $registry_url $registry_path --branch=$default_branch`)
+            run(`git clone $registry_url $registry_path`)
         else
             # this is really annoying/impossible to do with LibGit2
             git = gitcmd(registry_path, gitconfig)

--- a/src/types.jl
+++ b/src/types.jl
@@ -35,19 +35,20 @@ function get_registry(
 )
     if haskey(cache.registries, registry_url)
         registry_path = path(cache, registry_url)
+        default_branch = split(readchomp(`git symbolic-ref refs/remotes/origin/HEAD`), '/')[end]
 
         if !ispath(registry_path)
             mkpath(path(cache))
-            run(`git clone $registry_url $registry_path --branch=master`)
+            run(`git clone $registry_url $registry_path --branch=$default_branch`)
         else
             # this is really annoying/impossible to do with LibGit2
             git = gitcmd(registry_path, gitconfig)
             run(`$git config remote.origin.url $registry_url`)
-            run(`$git checkout -q -f master`)
+            run(`$git checkout -q -f $default_branch`)
             # uses config because git versions <2.17.0 did not have the -P option
-            run(`$git -c fetch.pruneTags fetch -q origin master`)
+            run(`$git -c fetch.pruneTags fetch -q origin $default_branch`)
             if force_reset
-                run(`$git reset -q --hard origin/master`)
+                run(`$git reset -q --hard origin/$default_branch`)
             end
         end
     else


### PR DESCRIPTION
Closes #50 

Builds on #43. I would ideally like #43 merged as @QuantumBits was the one with the original PR for this, but I couldn't find a way to push to his forked branch directly, so I opened up this one instead. The difference in this PR is that I look up the default branch directly from git as suggested by @StefanKarpinski rather than adding the default branch as a parameter to the function.