### PR TITLE
Fix get_registrator_tree_sha for old Julia versions and test on them

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,15 @@ jobs:
         arch:
           - x64
         include:
+          - os: ubuntu-latest
+            version: 1.1
+            arch: x64
+          - os: ubuntu-latest
+            version: 1.2
+            arch: x64
+          - os: ubuntu-latest
+            version: 1.3
+            arch: x64
           - os: windows-latest
             version: 1.4
             arch: x86

--- a/src/register.jl
+++ b/src/register.jl
@@ -538,7 +538,7 @@ function get_registrator_tree_sha()
     registry_tools_uuid = Base.UUID("d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4")
     reg_pkg = get(manifest, registrator_uuid,
                   get(manifest, registry_tools_uuid, nothing))
-    if reg_pkg !== nothing
+    if reg_pkg !== nothing && VERSION >= v"1.2.0-rc1" && reg_pkg.tree_hash !== nothing
         return reg_pkg.tree_hash
     end
     return "unknown"


### PR DESCRIPTION
This fixes the `get_registrator_tree_sha` function for 1.1 (didn't have pkg.tree_hash field) and 1.2 (couldn't print `nothing`). Tests now pass again on those versions.

This also turns on tests for older supported Julia versions (1.1, 1.2, 1.3) on just Linux, to avoid adding too many extra jobs to the matrix.

Closes https://github.com/JuliaRegistries/RegistryTools.jl/issues/52