### PR TITLE
Fix tests on Julia nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ run/stop*
 docs/build/
 docs/Manifest.toml
 .vscode
+
+# Temporary files and directories created by Julia:
+test/jl_*
+test/jl_*/
+test/registries/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.5.3"
+version = "1.5.4"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/register.jl
+++ b/src/register.jl
@@ -441,7 +441,11 @@ function check_compat!(pkg::Pkg.Types.Project,
                        regpaths::Vector{String},
                        status::ReturnStatus)
     if haskey(pkg.compat, "julia")
-        ver = Pkg.Types.semver_spec(pkg.compat["julia"])
+        if Base.VERSION >= v"1.7-"
+            ver = pkg.compat["julia"].val
+        else 
+            ver = Pkg.Types.semver_spec(pkg.compat["julia"])
+        end
         if any(map(x -> !isempty(intersect(Pkg.Types.VersionRange("0-0.6"), x)), ver.ranges))
             err = :julia_before_07_in_compat
             @debug(err)
@@ -516,7 +520,11 @@ function update_compat_file(pkg::Pkg.Types.Project,
             continue
         end
 
-        spec = Pkg.Types.semver_spec(version)
+        if Base.VERSION >= v"1.7-"
+            spec = version.val
+        else
+            spec = Pkg.Types.semver_spec(version)
+        end
         # The call to `map(versionrange, )` can be removed
         # once Pkg is updated to a version including
         # https://github.com/JuliaLang/Pkg.jl/pull/1181

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -5,6 +5,7 @@ using RegistryTools: DEFAULT_REGISTRY_URL,
     get_registry,
     gitcmd
 using LibGit2
+import Pkg
 using Pkg.TOML
 using Pkg.Types: Project
 
@@ -323,7 +324,12 @@ end
     import RegistryTools: update_compat_file
     mktempdir(@__DIR__) do temp_dir
         compat = Dict("julia" => "1.3")
-        pkg = Project(version = v"1.0.0", compat = compat)
+        if Base.VERSION >= v"1.7-"
+            compat2 = Dict((k, Pkg.Types.Compat(Pkg.Types.semver_spec(v), v)) for (k, v) in compat)
+            pkg = Project(version = v"1.0.0", compat = compat2)
+        else
+            pkg = Project(version = v"1.0.0", compat = compat)
+        end
         update_versions_file(pkg, joinpath(temp_dir, "Versions.toml"),
                              Dict{String, Any}(), repeat("0", 40))
         update_compat_file(pkg, temp_dir, VersionNumber[])


### PR DESCRIPTION
This PR fixes test failures on Julia nightly that were caused by changes in Pkg internals (specifically https://github.com/JuliaLang/Pkg.jl/pull/2480).

This PR also bumps the version number from `1.5.3` to `1.5.4`. Once this PR is merged, I will register a new release.