### PR TITLE
[breaking] Put packages inside of `/packages/A/`, `/packages/B/`, etc. instead of `/A/`, `/B/`, etc.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.5.6"
+version = "2.0.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/types.jl
+++ b/src/types.jl
@@ -156,7 +156,7 @@ function package_relpath(pkg::Pkg.Types.Project)
     return package_relpath(pkg.name)
 end
 function package_relpath(pkg_name::String)
-    path_components = [uppercase(pkg_name[1]), pkg_name]
+    path_components = ["packages", uppercase(pkg_name[1]), pkg_name]
     path_separator = "/"
     return join(path_components, path_separator)
 end

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -772,7 +772,7 @@ end
 end
 
 @testset "The `RegistryTools.package_relpath` function" begin
-    @test RegistryTools.package_relpath("Example") == "E/Example"
+    @test RegistryTools.package_relpath("Example") == "packages/E/Example"
 end
 
 end


### PR DESCRIPTION
See https://github.com/JuliaRegistries/General/issues/36948 for the context and motivation.

This is a breaking change, so I have bumped the major version number in `Project.toml`.