### PR TITLE
[NFC] Refactor the `package_relpath` function to make it easier for other packages to use it

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "1.5.4"
+version = "1.5.5"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/types.jl
+++ b/src/types.jl
@@ -153,7 +153,12 @@ end
 # Not using `joinpath` here since we don't want backslashes in
 # Registry.toml when running on Windows.
 function package_relpath(pkg::Pkg.Types.Project)
-    string(uppercase(pkg.name[1]), "/", pkg.name)
+    return package_relpath(pkg.name)
+end
+function package_relpath(pkg_name::String)
+    path_components = [uppercase(pkg_name[1]), pkg_name]
+    path_separator = "/"
+    return join(path_components, path_separator)
 end
 
 function Base.push!(reg::RegistryData, pkg::Pkg.Types.Project)

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -768,5 +768,9 @@ end
             """
     end
 end
+        
+@testset "The `RegistryTools.package_relpath` function" begin
+    @test RegistryTools.package_relpath("Example") == "E/Example"
+end
 
 end


### PR DESCRIPTION
I'd like to use the `RegistryTools.package_relpath` function in other packages (e.g. RegistryCI) in which I have the package name (as a `String`), but I don't necessarily have a `Pkg.Types.Project`.

This PR refactors the `RegistryTools.package_relpath` function and adds a method that takes in the package name as a string.

This PR has no functional change.