### PR TITLE
Remove `not_standard_first_version` check

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -123,10 +123,6 @@ function set_metadata!(regbr::RegBranch, status::ReturnStatus)
             regbr.metadata[complaint] = "Package version must be greater than 0.0.0"
         elseif check == :new_package_label
             add_label!(regbr, "new package")
-        elseif check == :not_standard_first_version
-            regbr.metadata[complaint] =
-                """This looks like a new registration that registers version $(data.version).
-                Ideally, you should register an initial release with 0.0.1, 0.1.0 or 1.0.0 version numbers"""
         elseif check == :version_less_than_all_existing
             regbr.metadata[complaint] = "Version $(data.version) less than least existing version $(data.least)"
         elseif check == :version_exists
@@ -190,9 +186,6 @@ function check_version!(version::VersionNumber, existing::Vector{VersionNumber},
     @assert issorted(existing)
     if isempty(existing)
         add!(status, :new_package_label)
-        if !(version in [v"0.0.1", v"0.1", v"1"])
-            add!(status, :not_standard_first_version, (version = version,))
-        end
     else
         idx = searchsortedlast(existing, version)
         if idx <= 0

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -141,9 +141,8 @@ end
     for ver in [v"0.0.2", v"0.3.2", v"4.3.2"]
         status = ReturnStatus()
         check_version!(ver, VersionNumber[], status)
-        @test hascheck(status, :not_standard_first_version)
         @test hascheck(status, :new_package_label)
-        @test length(status.triggered_checks) == 2
+        @test length(status.triggered_checks) == 1
         @test !haserror(status)
     end
 
@@ -401,15 +400,13 @@ end
 
             # Non-standard first version.
             (project_files = ["Example2"],
-             status = Symbol[:new_package, :new_package_label,
-                             :not_standard_first_version],
+             status = Symbol[:new_package, :new_package_label],
              regbranch = (error = false, warning = true,
                           kind = "New package", labels = String["new package"]))
 
             # Version zero.
             (project_files = ["Example5"],
-             status = Symbol[:new_package, :new_package_label, :version_zero,
-                             :not_standard_first_version],
+             status = Symbol[:new_package, :new_package_label, :version_zero],
              regbranch = (error = true, warning = true,
                           kind = "New package", labels = String["new package"]))
 


### PR DESCRIPTION
This check shows this message:

```
Also, note the warning: This looks like a new registration that registers version 0.1.1.
Ideally, you should register an initial release with 0.0.1, 0.1.0 or 1.0.0 version numbers
This can be safely ignored. However, if you want to fix this you can do so. Call
register() again after making the fix. This will update the Pull request.
```

This is confusing (it prompts users to change version number even if they do not
have to) and false: it is not true that changing the version number and
registering again will update the pull request, on the contrary it will open a
new pull request which will never be merged because it will conflict with the
previously opened PR.