### PR TITLE
merge in `project._weak_deps` if they exist

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -433,6 +433,9 @@ function update_deps_file(pkg::Pkg.Types.Project,
     end
 
     deps_data[pkg.version] = pkg.deps
+    @static if hasfield(Pkg.Types.Project, :_deps_weak)
+        merge!(deps_data[pkg.version], pkg._deps_weak)
+    end
     Compress.save(deps_file, deps_data)
 end
 


### PR DESCRIPTION
This will be required after https://github.com/JuliaLang/Pkg.jl/pull/3264 if people want to have a package *both*  as a normal dependency and as a weak dependency (for backward compatibility) where the normal dependency is ignored on later julia versions.