### PR TITLE
Revert "Write empty `Deps.toml` and `Compat.toml` files, but don't write empty `WeakDeps.toml` or `WeakCompat.toml` files"

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -387,14 +387,7 @@ function update_deps_file(pkg::Project,
         end
 
         deps_data[pkg.version] = deps
-        if file == "Deps.toml"
-            # We always write the `Deps.toml` file, even if it is empty
-            write_this_file = true
-        else
-            # We only write the `WeakDeps.toml` file if it is not empty
-            write_this_file = !isempty(deps_data) && !all(isempty, values(deps_data))
-        end
-        if write_this_file
+        if !isempty(deps_data) && !all(isempty, values(deps_data))
             Compress.save(deps_file, deps_data)
         end
     end
@@ -498,14 +491,7 @@ function update_compat_file(pkg::Project,
         end
 
         compat_data[pkg.version] = d
-        if file == "Compat.toml"
-            # We always write the `Compat.toml` file, even if it is empty
-            write_this_file = true
-        else
-            # We only write the `WeakCompat.toml` file if it is not empty
-            write_this_file = !isempty(compat_data) && !all(isempty, values(compat_data))
-        end
-        if write_this_file
+        if !isempty(compat_data) && !all(isempty, values(compat_data))
             Compress.save(compat_file, compat_data)
         end
     end


### PR DESCRIPTION
Reverts JuliaRegistries/RegistryTools.jl#82