### PR TITLE
Restore support for older Julias

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,11 @@ on:
     branches: [master, "release-*"]
     tags: ["*"]
   pull_request:
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `master` or `release-*` branches
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.1' # oldest Julia supported by this package
+          - '1.6' # current LTS
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
@@ -12,7 +12,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 AutoHashEquals = "0.2"
-julia = "1.6"
+julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -764,7 +764,6 @@ end
 @testset "weakdeps" begin
     import RegistryTools: ReturnStatus, check_and_update_registry_files
 
-    temp_dir = mktempdir(; cleanup=false)
     mktempdir(@__DIR__) do temp_dir
         registry_path = joinpath(temp_dir, "registry")
         projects_path = joinpath(@__DIR__, "project_files")


### PR DESCRIPTION
RegistryCI depends on RegistryTools.

On the General registry, RegistryCI runs the registry consistency tests on every minor release of Julia starting with Julia 1.3. This allows to catch registry issues that would impact older Julia clients.

So let's make sure that RegistryTools is compatible with older Julias.