### PR TITLE
Ignore .git suffix and url scheme in package url

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "2.2.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/src/register.jl
+++ b/src/register.jl
@@ -276,9 +276,10 @@ function check_package!(package_repo::AbstractString,
     # not been created yet.
     if isfile(package_file)
         repo = TOML.parsefile(package_file)["repo"]
+        @info("repo = $repo, package_repo = $package_repo")
         if isempty(package_repo)
             package_repo = repo
-        elseif repo != package_repo
+        elseif !same_apart_from_dotgit(repo, package_repo)
             err = :change_package_url
             @debug(err)
             add!(status, err)

--- a/src/register.jl
+++ b/src/register.jl
@@ -276,7 +276,6 @@ function check_package!(package_repo::AbstractString,
     # not been created yet.
     if isfile(package_file)
         repo = TOML.parsefile(package_file)["repo"]
-        @info("repo = $repo, package_repo = $package_repo")
         if isempty(package_repo)
             package_repo = repo
         elseif !same_apart_from_dotgit(repo, package_repo)

--- a/src/register.jl
+++ b/src/register.jl
@@ -278,7 +278,7 @@ function check_package!(package_repo::AbstractString,
         repo = TOML.parsefile(package_file)["repo"]
         if isempty(package_repo)
             package_repo = repo
-        elseif !same_apart_from_dotgit(repo, package_repo)
+        elseif !same_pkg_url(repo, package_repo)
             err = :change_package_url
             @debug(err)
             add!(status, err)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,15 +35,5 @@ function same_pkg_url(urla::HTTP.URI, urlb::HTTP.URI)
 end
 
 function same_pkg_path(patha::AbstractString, pathb::AbstractString)
-    if patha == pathb
-        return true
-    end
-
-    if endswith(patha, ".git")
-        return patha[1:end-4] == pathb
-    elseif endswith(pathb, ".git")
-        return pathb[1:end-4] == patha
-    end
-
-    return false
+    patha == pathb || patha * ".git" == pathb || patha == pathb * ".git"
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,5 @@
 import SHA
+import HTTP
 
 showsafe(x) = (x === nothing) ? "nothing" : x
 
@@ -24,15 +25,25 @@ end
 
 # Returns true if the two urls are the same. When the two urls are different
 # returns true if the only difference between the two urls is a .git at the end
-# . Returns false otherwise
-function same_apart_from_dotgit(urla, urlb)
-    if urla == urlb
+# or if only the scheme (http/https/ssh) is different. Returns false otherwise
+function same_pkg_url(urla::AbstractString, urlb::AbstractString)
+    same_pkg_url(HTTP.URI(string(urla)), HTTP.URI(string(urlb)))
+end
+
+function same_pkg_url(urla::HTTP.URI, urlb::HTTP.URI)
+    urla.host == urlb.host && same_pkg_path(urla.path, urlb.path)
+end
+
+function same_pkg_path(patha::AbstractString, pathb::AbstractString)
+    if patha == pathb
         return true
     end
 
-    if length(urla) > length(urlb)
-        return urla[end-3:end] == ".git" && urla[1:end-4] == urlb
-    else
-        return urlb[end-3:end] == ".git" && urlb[1:end-4] == urla
+    if endswith(patha, ".git")
+        return patha[1:end-4] == pathb
+    elseif endswith(pathb, ".git")
+        return pathb[1:end-4] == patha
     end
+
+    return false
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,3 +21,18 @@ function registration_branch(pkg::Project; url::AbstractString)
     url_hash_trunc = url_hash[1:10]
     return "registrator-$(lowercase(pkg.name))-$(string(pkg.uuid)[1:8])-v$(pkg.version)-$(url_hash_trunc)"
 end
+
+# Returns true if the two urls are the same. When the two urls are different
+# returns true if the only difference between the two urls is a .git at the end
+# . Returns false otherwise
+function same_apart_from_dotgit(urla, urlb)
+    if urla == urlb
+        return true
+    end
+
+    if length(urla) > length(urlb)
+        return urla[end-3:end] == ".git" && urla[1:end-4] == urlb
+    else
+        return urlb[end-3:end] == ".git" && urlb[1:end-4] == urla
+    end
+end

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -4,7 +4,8 @@ using RegistryTools: DEFAULT_REGISTRY_URL,
     showsafe,
     registration_branch,
     get_registry,
-    gitcmd
+    gitcmd,
+    same_apart_from_dotgit
 using LibGit2
 import Pkg
 using Pkg.TOML
@@ -42,6 +43,33 @@ end
         ))
         url = "https://julialang.org/"
         @test registration_branch(example; url=url) == "registrator-example-698ec630-v1.10.2-0251df46a9"
+    end
+
+    @testset "same_apart_from_dotgit" begin
+        @test same_apart_from_dotgit(
+            "https://github.com/JuliaLang/Example.jl",
+            "https://github.com/JuliaLang/Example.jl"
+        )
+
+        @test same_apart_from_dotgit(
+            "https://github.com/JuliaLang/Example.jl.git",
+            "https://github.com/JuliaLang/Example.jl"
+        )
+
+        @test same_apart_from_dotgit(
+            "https://github.com/JuliaLang/Example.jl",
+            "https://github.com/JuliaLang/Example.jl.git"
+        )
+
+        @test !same_apart_from_dotgit(
+            "https://github.com/JuliaLang/Example.jl",
+            "https://github.com/JuliaLang/Another.jl"
+        )
+
+        @test !same_apart_from_dotgit(
+            "https://github.com/JuliaLang/Example.jl.git",
+            "https://github.com/JuliaLang/Another.jl"
+        )
     end
 end
 

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -5,7 +5,8 @@ using RegistryTools: DEFAULT_REGISTRY_URL,
     registration_branch,
     get_registry,
     gitcmd,
-    same_apart_from_dotgit
+    same_pkg_url,
+    same_pkg_path
 using LibGit2
 import Pkg
 using Pkg.TOML
@@ -45,30 +46,40 @@ end
         @test registration_branch(example; url=url) == "registrator-example-698ec630-v1.10.2-0251df46a9"
     end
 
-    @testset "same_apart_from_dotgit" begin
-        @test same_apart_from_dotgit(
+    @testset "same_pkg_url" begin
+        @test same_pkg_url(
             "https://github.com/JuliaLang/Example.jl",
             "https://github.com/JuliaLang/Example.jl"
         )
 
-        @test same_apart_from_dotgit(
+        @test same_pkg_url(
             "https://github.com/JuliaLang/Example.jl.git",
             "https://github.com/JuliaLang/Example.jl"
         )
 
-        @test same_apart_from_dotgit(
+        @test same_pkg_url(
             "https://github.com/JuliaLang/Example.jl",
             "https://github.com/JuliaLang/Example.jl.git"
         )
 
-        @test !same_apart_from_dotgit(
+        @test !same_pkg_url(
             "https://github.com/JuliaLang/Example.jl",
             "https://github.com/JuliaLang/Another.jl"
         )
 
-        @test !same_apart_from_dotgit(
+        @test !same_pkg_url(
             "https://github.com/JuliaLang/Example.jl.git",
             "https://github.com/JuliaLang/Another.jl"
+        )
+
+        @test same_pkg_url(
+            "https://github.com/JuliaLang/Example.jl",
+            "ssh://git@github.com/JuliaLang/Example.jl"
+        )
+
+        @test same_pkg_url(
+            "https://github.com/JuliaLang/Example.jl",
+            "ssh://git@github.com/JuliaLang/Example.jl.git"
         )
     end
 end


### PR DESCRIPTION
Some git services require you to have the ".git" suffix in the package URL and some git services wont work if you provide the ".git" suffix (Ex: Azure DevOps). This PR removes the "Package URL changed error" if only the ".git" suffix is added or removed in the registration request i.e, the suffix is the only change to the URL.

Edit: Updated the PR to also ignore the url scheme (http/https/ssh) 