### PR TITLE
Add a method for `registration_branch(pkg::String; url::AbstractString)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ docs/Manifest.toml
 test/jl_*
 test/jl_*/
 test/registries/
+
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/types.jl
+++ b/src/types.jl
@@ -38,7 +38,7 @@ struct Project
     extras::Dict{String, String}
 end
 
-Project(project_file::String) = Project(isfile(project_file) ? TOML.parsefile(project_file) : Dict())
+Project(project_file::AbstractString) = Project(isfile(project_file) ? TOML.parsefile(project_file) : Dict())
 function Project(d::Dict)
     name = get(d, "name", nothing)
     uuid = get(d, "uuid", nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,6 +12,7 @@ function gitcmd(path::AbstractString, gitconfig::Dict)
 end
 
 """
+    registration_branch(pkg::AbstractString; url::AbstractString) -> String
     registration_branch(pkg::RegistryTools.Project; url::AbstractString) -> String
 
 Generate the name for the registry branch used to register the package version.
@@ -20,4 +21,8 @@ function registration_branch(pkg::Project; url::AbstractString)
     url_hash = bytes2hex(SHA.sha256(url))
     url_hash_trunc = url_hash[1:10]
     return "registrator-$(lowercase(pkg.name))-$(string(pkg.uuid)[1:8])-v$(pkg.version)-$(url_hash_trunc)"
+end
+function registration_branch(project_file::AbstractString; url::AbstractString)
+    proj = Project(project_file)
+    return registration_branch(proj; url = url)
 end

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -638,8 +638,12 @@ end
 
             projects_path = joinpath(@__DIR__, "project_files")
             project_file = joinpath(projects_path, "Example18.toml")
-            pkg = Project(project_file)
-            package_repo = "http://example.com/$(pkg.name).git"
+            pkg = pkg_f(project_file)
+            if pkg isa AbstractString
+                package_repo = "http://example.com/$(pkg).git"
+            else
+                package_repo = "http://example.com/$(pkg.name).git"
+            end
             tree_hash = repeat("0", 40)
             registry_repo = "file://$(registry1_path)"
             deps_repo = "file://$(registry2_path)"

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -622,41 +622,43 @@ end
 # version of one of the packages with a dependency to the other
 # package. The registration is pushed to a new branch via a file URL.
 @testset "register" begin
-    mktempdir(@__DIR__) do temp_dir
-        registry1_path = joinpath(temp_dir, "Registry1")
-        status = create_and_populate_registry(registry1_path, "Registry1",
-                                              "7e1d4fce-5fe6-405e-8bac-078d4138e9a2",
-                                              "Example1")
-        @test !haserror(status)
+    for pkg_f in [identity, Project]
+        mktempdir(@__DIR__) do temp_dir
+            registry1_path = joinpath(temp_dir, "Registry1")
+            status = create_and_populate_registry(registry1_path, "Registry1",
+                                                  "7e1d4fce-5fe6-405e-8bac-078d4138e9a2",
+                                                  "Example1")
+            @test !haserror(status)
 
-        registry2_path = joinpath(@__DIR__, temp_dir, "Registry2")
-        status = create_and_populate_registry(registry2_path, "Registry2",
-                                              "a5a8be26-c942-4674-beee-533a0e81ac1d",
-                                              "Dep1")
-        @test !haserror(status)
+            registry2_path = joinpath(@__DIR__, temp_dir, "Registry2")
+            status = create_and_populate_registry(registry2_path, "Registry2",
+                                                  "a5a8be26-c942-4674-beee-533a0e81ac1d",
+                                                  "Dep1")
+            @test !haserror(status)
 
-        projects_path = joinpath(@__DIR__, "project_files")
-        project_file = joinpath(projects_path, "Example18.toml")
-        pkg = Project(project_file)
-        package_repo = "http://example.com/$(pkg.name).git"
-        tree_hash = repeat("0", 40)
-        registry_repo = "file://$(registry1_path)"
-        deps_repo = "file://$(registry2_path)"
-        regbr = register(package_repo, pkg, tree_hash, registry = registry_repo,
-                         registry_deps = [deps_repo], push = true,
-                         gitconfig = TEST_GITCONFIG)
-        @test !haskey(regbr.metadata, "error") && !haskey(regbr.metadata, "warning")
-        git = gitcmd(registry1_path, TEST_GITCONFIG)
-        branches = readlines(`$git branch`)
-        @test length(branches) == 2
+            projects_path = joinpath(@__DIR__, "project_files")
+            project_file = joinpath(projects_path, "Example18.toml")
+            pkg = Project(project_file)
+            package_repo = "http://example.com/$(pkg.name).git"
+            tree_hash = repeat("0", 40)
+            registry_repo = "file://$(registry1_path)"
+            deps_repo = "file://$(registry2_path)"
+            regbr = register(package_repo, pkg, tree_hash, registry = registry_repo,
+                             registry_deps = [deps_repo], push = true,
+                             gitconfig = TEST_GITCONFIG)
+            @test !haskey(regbr.metadata, "error") && !haskey(regbr.metadata, "warning")
+            git = gitcmd(registry1_path, TEST_GITCONFIG)
+            branches = readlines(`$git branch`)
+            @test length(branches) == 2
+        end
+
+        # Clean up the registry cache created by `register`.
+        rm(joinpath(@__DIR__, "registries", "7e1d4fce-5fe6-405e-8bac-078d4138e9a2"),
+           recursive = true)
+        rm(joinpath(@__DIR__, "registries", "a5a8be26-c942-4674-beee-533a0e81ac1d"),
+           recursive = true)
+        rm(joinpath(@__DIR__, "registries"))
     end
-
-    # Clean up the registry cache created by `register`.
-    rm(joinpath(@__DIR__, "registries", "7e1d4fce-5fe6-405e-8bac-078d4138e9a2"),
-       recursive = true)
-    rm(joinpath(@__DIR__, "registries", "a5a8be26-c942-4674-beee-533a0e81ac1d"),
-       recursive = true)
-    rm(joinpath(@__DIR__, "registries"))
 end
 
 @testset "find_registered_version" begin

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -639,11 +639,7 @@ end
             projects_path = joinpath(@__DIR__, "project_files")
             project_file = joinpath(projects_path, "Example18.toml")
             pkg = pkg_f(project_file)
-            if pkg isa AbstractString
-                package_repo = "http://example.com/$(pkg).git"
-            else
-                package_repo = "http://example.com/$(pkg.name).git"
-            end
+            package_repo = "http://example.com/Example.git"
             tree_hash = repeat("0", 40)
             registry_repo = "file://$(registry1_path)"
             deps_repo = "file://$(registry2_path)"

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -650,6 +650,9 @@ end
             regbr = register(package_repo, pkg, tree_hash, registry = registry_repo,
                              registry_deps = [deps_repo], push = true,
                              gitconfig = TEST_GITCONFIG)
+            if haskey(regbr.metadata, "error") || haskey(regbr.metadata, "warning")
+                @info "" get(regbr.metadata, "error", nothing) get(regbr.metadata, "warning", nothing)
+            end
             @test !haskey(regbr.metadata, "error") && !haskey(regbr.metadata, "warning")
             git = gitcmd(registry1_path, TEST_GITCONFIG)
             branches = readlines(`$git branch`)


### PR DESCRIPTION
If you call `register`, and you don't specify a value for the `branch` kwarg, then you'll hit this line while trying to compute the default value for `branch`:

https://github.com/JuliaRegistries/RegistryTools.jl/blob/0b08dcc1e65f9d67d6666a8ea40e02bf85b9179e/src/register.jl#L602-L602

Recall the allowed types for `pkg`:

https://github.com/JuliaRegistries/RegistryTools.jl/blob/0b08dcc1e65f9d67d6666a8ea40e02bf85b9179e/src/register.jl#L594-L594

So `pkg` can be either `String` or `Project`. So we need to make sure that `registration_branch(pkg; url)` has methods for both `pkg::String` and `pkg::Project`. That's what this PR does.