### PR TITLE
Fix locale of Git command in `get_registry_default_branch`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -22,7 +22,7 @@ function path(cache::RegistryCache, registry_url::AbstractString)
 end
 
 function get_registry_default_branch(git::Cmd)
-    lines = collect(eachline(`$git remote show origin`))
+    lines = collect(eachline(Cmd(`$git remote show origin`, env=("LANG" => "en_US.UTF-8",))))
     idx = findfirst(x -> occursin("HEAD branch", x), lines)
     idx === nothing && error("Failed to get default branch of registry")
     strip(split(lines[idx], ":")[2])


### PR DESCRIPTION
In environments where language is set to something different to English, Git output is printed in the respective language (e.g. Spanish).

This commit forces the output of a Git command to be in American English for proper parsing.