### PR TITLE
Use git clean to remove untracked files; shallow clone for faster clones

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/types.jl
+++ b/src/types.jl
@@ -69,12 +69,13 @@ function get_registry(
 
         if !ispath(registry_path)
             mkpath(path(cache))
-            run(`git clone $registry_url $registry_path`)
+            run(`git clone -q --depth=1 $registry_url $registry_path`)
         else
             # this is really annoying/impossible to do with LibGit2
             git = gitcmd(registry_path, gitconfig)
             run(`$git config remote.origin.url $registry_url`)
             registry_defbranch = get_registry_default_branch(git)
+            run(`$git clean -fd`)
             run(`$git checkout -q -f $registry_defbranch`)
             # uses config because git versions <2.17.0 did not have the -P option
             run(`$git -c fetch.pruneTags fetch -q origin $registry_defbranch`)
@@ -85,7 +86,7 @@ function get_registry(
     else
         registry_temp = mktempdir(mkpath(path(cache)))
         try
-            run(`git clone $registry_url $registry_temp`)
+            run(`git clone -q --depth=1 $registry_url $registry_temp`)
             reg = parse_registry(joinpath(registry_temp, "Registry.toml"))
             registry_uuid = cache.registries[registry_url] = reg.uuid
             registry_path = path(cache, registry_uuid)


### PR DESCRIPTION
- When the registration server crashes abruptly it can sometimes leave behind untracked files from a previous registration. This can cause issues like https://github.com/JuliaRegistries/General/issues/81954. Here I added a `git clean -fd` before checkout so that untracked files will be cleaned.
- Added `-q --depth=1` to `git clone`s so that cloning will be faster and quieter in the logs.