### PR TITLE
Explicit imports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,12 @@ authors = ["Stefan Karpinski <stefan@karpinski.org>"]
 version = "2.2.3"
 
 [deps]
-AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-AutoHashEquals = "0.2"
 julia = "1.1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "2.2.3"
+version = "2.3.0"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/src/RegistryTools.jl
+++ b/src/RegistryTools.jl
@@ -5,7 +5,6 @@ export register
 export check_and_update_registry_files
 export find_registered_version
 
-using AutoHashEquals
 using LibGit2
 using Pkg: Pkg, TOML, GitTools
 using UUIDs

--- a/src/RegistryTools.jl
+++ b/src/RegistryTools.jl
@@ -5,9 +5,9 @@ export register
 export check_and_update_registry_files
 export find_registered_version
 
-using LibGit2
+import LibGit2
 using Pkg: Pkg, TOML, GitTools
-using UUIDs
+using UUIDs: UUID
 
 const DEFAULT_REGISTRY_URL = "https://github.com/JuliaRegistries/General"
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -102,7 +102,7 @@ function get_registry(
     return LibGit2.GitRepo(registry_path)
 end
 
-@auto_hash_equals struct RegistryData
+struct RegistryData
     name::String
     uuid::UUID
     repo::Union{String, Nothing}

--- a/test/compress.jl
+++ b/test/compress.jl
@@ -1,4 +1,4 @@
-using Pkg
+import Pkg
 using RegistryTools.Compress: compress_versions, load, compress
 
 @testset "compress_versions()" begin

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -122,7 +122,12 @@ end
         written_registry = sprint(TOML.print, registry_data)
         written_registry_data = parse_registry(IOBuffer(written_registry))
 
-        @test written_registry_data == registry_data
+        # Note: This used to be `written_registry_data ==
+        # registry_data` but it seemed a little silly to depend on
+        # AutoHashEquals for this test only.
+        for field in fieldnames(RegistryData)
+            @test getfield(written_registry_data, field) == getfield(registry_data, field)
+        end
         @test written_registry == registry
     end
 

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -320,6 +320,12 @@ end
     end
 end
 
+# Adapts regression tests for compat files to the changes in
+# https://github.com/JuliaLang/Pkg.jl/pull/3580.
+function read_compat(filename)
+    return replace(read(filename, String), " - " => "-")
+end
+
 @testset "compat_file" begin
     import RegistryTools: update_compat_file
     mktempdir(@__DIR__) do temp_dir
@@ -330,10 +336,10 @@ end
         update_compat_file(pkg, temp_dir, VersionNumber[])
         compat_file = joinpath(temp_dir, "Compat.toml")
         @test isfile(compat_file)
-        @test read(compat_file, String) == """
-                                           [1]
-                                           julia = "1.3.0-1"
-                                           """
+        @test read_compat(compat_file) == """
+                                          [1]
+                                          julia = "1.3.0-1"
+                                          """
     end
 end
 
@@ -785,13 +791,13 @@ end
                                         registry_path,
                                         registry_deps_paths, status)
         path = RegistryTools.package_relpath("Example")
-        @test read(joinpath(registry_path, path, "Compat.toml"), String) ==
+        @test read_compat(joinpath(registry_path, path, "Compat.toml")) ==
             """
             [1]
             UUIDs = "1.8.0-1"
             julia = "1.1.0-1"
             """
-        @test read(joinpath(registry_path, path, "WeakCompat.toml"), String) ==
+        @test read_compat(joinpath(registry_path, path, "WeakCompat.toml")) ==
             """
             [1]
             UUIDs = "1.8.0-1"

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -4,10 +4,12 @@ using RegistryTools: DEFAULT_REGISTRY_URL,
     showsafe,
     registration_branch,
     get_registry,
-    gitcmd
-using LibGit2
-import Pkg
-using Pkg.TOML
+    gitcmd,
+    register,
+    find_registered_version,
+    RegistryData
+import LibGit2
+using Pkg: TOML
 
 using Test
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,22 @@
 import RegistryTools
 using Test: @testset, @test
+import Pkg
 
 @testset "RegistryTools" begin
 
 include("regedit.jl")
 include("compress.jl")
+
+# ExplicitImports does not support as old Julia versions as RegistryTools does.
+# Change this to a regular test dependency when it becomes possible, i.e.
+# when pre-1.7 support is dropped.
+if VERSION >= v"1.7"
+Pkg.add(name = "ExplicitImports", uuid = "7d51a73a-1435-4ff3-83d9-f097790105c7", preserve=Pkg.PRESERVE_ALL)
+using ExplicitImports: check_no_implicit_imports, check_no_stale_explicit_imports
+@testset "ExplicitImports" begin
+    @test isnothing(check_no_implicit_imports(RegistryTools))
+    @test isnothing(check_no_stale_explicit_imports(RegistryTools))
+end
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-using RegistryTools
-using Test
+import RegistryTools
+using Test: @testset, @test
 
 @testset "RegistryTools" begin
 


### PR DESCRIPTION
* Stop doing implicit imports and be explicit about all imports. Thanks to @ericphanson for ExplicitImports.jl.
* Make regression tests of compat files ignore whitespace around hyphens. Fixes #99.
* Remove dependency on AutoHashEquals. This was only used for a roundtrip test of the `RegistryData` struct and had no reasonable utility externally. Closes #95.
* (Added) Check in the tests that imports remain explicit.
