### PR TITLE
fix compression to not be based on string representation of VersionSpec

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -383,7 +383,7 @@ function update_deps_file(pkg::Project,
         if isfile(deps_file)
             deps_data = Compress.load(deps_file, old_versions)
         else
-            deps_data = Dict()
+            deps_data = Dict{VersionNumber,Dict{String,Union{Base.UUID, VersionSpec}}}()
         end
 
         deps_data[pkg.version] = deps
@@ -472,10 +472,10 @@ function update_compat_file(pkg::Project,
         if isfile(compat_file)
             compat_data = Compress.load(compat_file, old_versions)
         else
-            compat_data = Dict()
+            compat_data = Dict{VersionNumber,Dict{String,Union{Base.UUID, VersionSpec}}}()
         end
 
-        d = Dict()
+        d = Dict{String,Union{Base.UUID, VersionSpec}}()
         for (name, version) in pkg.compat
             # Ignore julia compat for weak
             if file == "WeakCompat.toml" && name == "julia"
@@ -485,16 +485,8 @@ function update_compat_file(pkg::Project,
                 @debug("$name is a not in relevant dependency list; omitting from Compat.toml")
                 continue
             end
-
             spec = Pkg.Types.semver_spec(version)
-
-            # The call to `map(versionrange, )` can be removed
-            # once Pkg is updated to a version including
-            # https://github.com/JuliaLang/Pkg.jl/pull/1181
-            # and support for older versions is dropped.
-            ranges = map(r->versionrange(r.lower, r.upper), spec.ranges)
-            ranges = VersionSpec(ranges).ranges # this combines joinable ranges
-            d[name] = length(ranges) == 1 ? string(ranges[1]) : map(string, ranges)
+            d[name] = spec
         end
 
         compat_data[pkg.version] = d

--- a/src/types.jl
+++ b/src/types.jl
@@ -34,8 +34,8 @@ struct Project
     name::Union{Nothing, String}
     uuid::Union{Nothing, UUID}
     version::Union{Nothing, VersionNumber}
-    deps::Dict{String, String}
-    weakdeps::Dict{String, String}
+    deps::Dict{String, Base.UUID}
+    weakdeps::Dict{String, Base.UUID}
     compat::Dict{String, String}
     extras::Dict{String, String}
 end
@@ -48,7 +48,9 @@ function Project(d::Dict)
     version = get(d, "version", nothing)
     version !== nothing && (version = VersionNumber(version))
     deps = get(Dict, d, "deps")
+    deps = Dict(k => Base.UUID(v) for (k,v) in deps)
     weakdeps = get(Dict, d, "weakdeps")
+    weakdeps = Dict(k => Base.UUID(v) for (k,v) in weakdeps)
     compat = get(Dict, d, "compat")
     extras = get(Dict, d, "extras")
     Project(name, uuid, version, deps, weakdeps, compat, extras)

--- a/test/compress.jl
+++ b/test/compress.jl
@@ -1,30 +1,31 @@
 import Pkg
+using Pkg.Types: VersionSpec, VersionRange
 using RegistryTools.Compress: compress_versions, load, compress
 
 @testset "compress_versions()" begin
     # Test exact version matching
     vs = [v"1.1.0", v"1.1.1", v"1.1.2"]
-    @test compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1.1.1")
+    @test compress_versions(vs, [vs[2]]) == VersionSpec("1.1.1")
 
     # Test holes
     vs = [v"1.1.0", v"1.1.1", v"1.1.4"]
-    @test compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1.1.1")
+    @test compress_versions(vs, [vs[2]]) == VersionSpec("1.1.1")
 
     # Test patch variation with length(subset) > 1
     vs = [v"1.1.0", v"1.1.1", v"1.1.2", v"1.1.3", v"1.2.0"]
-    @test compress_versions(vs, [vs[2], vs[3]]) == Pkg.Types.VersionSpec("1.1.1-1.1.2")
+    @test compress_versions(vs, [vs[2], vs[3]]) == VersionSpec("1.1.1-1.1.2")
 
     # Test minor variation
     vs = [v"1.1.0", v"1.1.1", v"1.2.0"]
-    @test compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1.1.1-1.1")
+    @test compress_versions(vs, [vs[2]]) == VersionSpec("1.1.1-1.1")
 
     # Test major variation
     vs = [v"1.1.0", v"1.1.1", v"1.2.0", v"2.0.0"]
-    @test compress_versions(vs, [vs[2], vs[3]]) == Pkg.Types.VersionSpec("1.1.1-1")
+    @test compress_versions(vs, [vs[2], vs[3]]) == VersionSpec("1.1.1-1")
 
     # Test build numbers and prerelease values are ignored
     vs = [v"1.1.0-alpha", v"1.1.0+0", v"1.1.0+1"]
-    @test compress_versions(vs, [vs[2]]) == Pkg.Types.VersionSpec("1")
+    @test compress_versions(vs, [vs[2]]) == VersionSpec("1")
 end
 
 @testset "Compress.load" begin
@@ -40,10 +41,10 @@ end
             """
         write(compat_file, good_compat)
         compat = load(compat_file, versions)
-        @test compat[v"1.0.0"] == Dict("julia" => "1")
-        @test compat[v"1.1.0"] == Dict("julia" => "1")
-        @test compat[v"1.2.0"] == Dict("julia" => "1.3.0-1")
-        @test compat[v"1.3.0"] == Dict("julia" => "1.3.0-1")
+        @test compat[v"1.0.0"] == Dict("julia" => VersionSpec("1"))
+        @test compat[v"1.1.0"] == Dict("julia" => VersionSpec("1"))
+        @test compat[v"1.2.0"] == Dict("julia" => VersionSpec("1.3.0-1"))
+        @test compat[v"1.3.0"] == Dict("julia" => VersionSpec("1.3.0-1"))
 
         # Overlapping ranges.
         bad_compat = """
@@ -58,18 +59,45 @@ end
     end
 end
 
+# Note, `compress` should never be called with "mixed input data"
+# so the test below was edited to only use uuids.
 @testset "issue#46: compress with mixed input data" begin
     pkglibdl_str = Dict("Pkg" => "44cfe95a-1eb2-52ea-b672-e2afdf69b78f",
                         "Libdl" => "8f399da3-3557-5675-b5ff-fb832c97cbdb")
     pkglibdl_uuid = Dict{String, Base.UUID}(k => Base.UUID(v) for (k, v) in pkglibdl_str)
-    uncompressed = Dict{VersionNumber, Dict{Any, Any}}(
-        v"0.21.1+0" => pkglibdl_str,
-        v"0.22.0+0" => pkglibdl_str,
-        v"0.22.1+0" => pkglibdl_uuid
-        )
+    uncompressed = Dict{VersionNumber,Dict{String,Union{Base.UUID, VersionSpec}}}(
+        v"0.21.1+0" => pkglibdl_uuid,
+        v"0.22.0+0" => pkglibdl_uuid,
+        v"0.22.1+0" => pkglibdl_uuid,
+    )
     versions = VersionNumber[ v"0.21.1+0", v"0.22.0+0"]
     compressed = compress("/dev/null", uncompressed, versions)
-    @test compressed == Dict{String,Any}("0" => pkglibdl_str)
+    @test compressed == Dict(VersionRange("0") => pkglibdl_uuid)
+end
+
+@testset "compress with different formating of version ranges" begin
+     mktempdir(@__DIR__) do temp_dir
+        versions = [v"1.0.0", v"1.0.1", v"1.1.0", v"1.2.0", v"1.3.0", v"1.4.0", v"1.4.1", v"1.4.2", v"1.4.3", v"1.4.4"]
+        compat_file = joinpath(temp_dir, "Compat.toml")
+        content = """
+        [1]
+        Preferences = "1"
+
+        ["1 - 1.4.3"]
+        JuliaSyntax = "0.4.10-0.4"
+        julia = "1.10.0-1"
+
+        ["1.4.4 - 1"]
+        JuliaSyntax = "0.4.10 - 0.4"
+        julia = "1.10.0 - 1"
+        """
+        write(compat_file, content)
+        uncompressed = load(compat_file, versions)
+        compressed = compress("/dev/null", uncompressed, versions)
+        # Check that this gets compressed properly
+        #
+        @test length(keys(compressed)) == 1
+     end
 end
 
 import RegistryTools.Compress
@@ -79,7 +107,7 @@ import Pkg.TOML
     git = Sys.which("git")
     git === nothing && return
     mktempdir() do dir
-        run(`$git clone https://github.com/JuliaRegistries/General $dir`)
+        run(`$git clone --depth=1 https://github.com/JuliaRegistries/General $dir`)
         reg = TOML.parsefile(abspath(dir, "Registry.toml"))
         for (uuid, data) in reg["packages"]
             for f in abspath.("General", data["path"], ("Deps.toml", "Compat.toml"))


### PR DESCRIPTION
The JuliaRegistrator bot recently updated to julia 1.11 and due to https://github.com/JuliaLang/Pkg.jl/pull/3580 this caused a difference in how versions ranges are printed. This apparently caused compress to stop functioning properly (as can be seen in https://github.com/JuliaRegistries/General/pull/135338/files).

The added test mimics this and we can see:

```
julia> uncompressed = load(compat_file, versions)
Dict{VersionNumber, Dict{Any, Any}} with 10 entries:
  v"1.4.0" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.0.1" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.4.4" => Dict("JuliaSyntax"=>"0.4.10 - 0.4", "julia"=>"1.10.…
  v"1.0.0" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.4.2" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.2.0" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.1.0" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.3.0" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.4.3" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…
  v"1.4.1" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10.0-…

julia> compressed = compress("/dev/null", uncompressed, versions)
Dict{String, Dict{String, Any}} with 3 entries:
  "1.4.4 - 1" => Dict("JuliaSyntax"=>"0.4.10 - 0.4", "julia"=>"1.…
  "1 - 1.4.3" => Dict("JuliaSyntax"=>"0.4.10-0.4", "julia"=>"1.10…
  "1"         => Dict("Preferences"=>"1")
```

that the difference in the string representation of the version range causes the versions to not be merged. After this PR we have:

```
julia> uncompressed = load(compat_file, versions)
Dict{VersionNumber, Dict{String, Union{Base.UUID, Pkg.Versions.VersionSpec}}} with 10 entries:
  v"1.4.0" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.0.1" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.4.4" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.0.0" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.4.2" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.2.0" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.1.0" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.3.0" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.4.3" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…
  v"1.4.1" => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpec("1.10.0…

julia> compressed = compress("/dev/null", uncompressed, versions)
Dict{Pkg.Versions.VersionRange, Dict{String, Union{Base.UUID, Pkg.Versions.VersionSpec}}} with 1 entry:
  VersionRange("1") => Dict("JuliaSyntax"=>VersionSpec("0.4.10 - 0.4"), "julia"=>VersionSpe
```

I did strengthen up the types of the internal dicts because I noticed we were putting all kinds of stuff in them which was quite brittle.

cc @GunnarFarneback @giordano @ericphanson 