### PR TITLE
Allow registring packages with missing dependencies

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -14,7 +14,6 @@ const mandatory_errors = [:version_exists,
 const registrator_errors = [:version_zero,
                             :version_less_than_all_existing,
                             :change_package_url,
-                            :dependency_not_found,
                             :julia_before_07_in_compat,
                             :invalid_compat,
                             :unexpected_registration_error


### PR DESCRIPTION
It commonly happens that someone wants to register 2 or more related packages that depend on each other. Because Registrator.jl enforces all dependencies are registered at registration time, this means one needs to serially wait out the dependency tree (or do tricks like rm the dep, register, start the 3 day wait, then add the dep and re-trigger registration). Community review can proceed in parallel so I think it's totally fine to register with unregisterd deps; they will fail the "package can load check" in RegistryCI which is the ultimate check, but you can at least start the waiting period.

The mechanism I propose to do that is to remove the check from `registrator_errors` which are meant to be the ones enforced by Registrator, then update Registrator to use this new version. Registrator does not pass any kwargs to `register` so it uses the defaults: https://github.com/JuliaRegistries/Registrator.jl/blob/b468d1955fe239d6229f1e4f4fd1a4a1ec2a4339/src/RegService.jl#L36.

An alternate path would be to update Registrator.jl itself to own the kwargs it uses and stop passing this one. That seems reasonable to me but as they are currently owned by RegistryTools the simplest (and lowest effort for me) fix is to update them here.

This is probably breaking though as it changes the defaults. Not sure that matters, RegistryTools surely does not have many dependent packages.