### PR TITLE
Support multiple tree hashes.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegistryTools"
 uuid = "d1eb7eb1-105f-429d-abf5-b0f65cb9e2c4"
 authors = ["Stefan Karpinski <stefan@karpinski.org>"]
-version = "2.4.3"
+version = "2.5.0"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/src/register.jl
+++ b/src/register.jl
@@ -326,8 +326,13 @@ end
 function update_versions_file(pkg::Project,
                               versions_file::AbstractString,
                               versions_data::Dict{String, Any},
-                              tree_hash::AbstractString)
-    version_info = Dict{String, Any}("git-tree-sha1" => string(tree_hash))
+                              tree_hash)
+    if tree_hash isa AbstractString
+        version_info = Dict{String, Any}("git-tree-sha1" => string(tree_hash))
+    else
+        version_info = Dict{String, Any}("git-tree-$(lowercase(string(key)))" => string(value)
+                                         for (key, value) in pairs(tree_hash))
+    end
     versions_data[string(pkg.version)] = version_info
 
     open(versions_file, "w") do io
@@ -339,12 +344,12 @@ function update_versions_file(pkg::Project,
             if occursin(Base.VERSION_REGEX, x)
                 return VersionNumber(x)
             else
-                if x == "git-tree-sha1"
-                    return 1
+                if startswith(x, "git-tree-sha1")
+                    return (1, x)
                 elseif x == "yanked"
-                    return 2
+                    return (2, x)
                 else
-                    return 3
+                    return (3, x)
                 end
             end
         end
@@ -578,7 +583,7 @@ errors or warnings that occurred.
 
 * `package_repo::AbstractString`: The git repository URL for the package to be registered. If empty, keep the stored repository URL.
 * `pkg::String`: the path of the project file for the package to be registered
-* `tree_hash::AbstractString`: the tree hash (not commit hash) of the package revision to be registered
+* `tree_hash`: the tree hash (not commit hash) of the package revision to be registered. This can either be an `AbstractString` for a single SHA1 hash or a named tuple of hash algorithms and hashes.
 
 # Keyword Arguments
 
@@ -591,7 +596,7 @@ errors or warnings that occurred.
 * `gitconfig::Dict=Dict()`: dictionary of configuration options for the `git` command
 """
 function register(
-    package_repo::AbstractString, pkg::Union{String, Project}, tree_hash::AbstractString;
+    package_repo::AbstractString, pkg::Union{String, Project}, tree_hash;
     registry::AbstractString = DEFAULT_REGISTRY_URL,
     registry_fork::AbstractString = registry,
     registry_deps::Vector{<:AbstractString} = AbstractString[],
@@ -657,7 +662,7 @@ function register(
 
         UUID: $(pkg.uuid)
         Repo: $(package_repo)
-        Tree: $(string(tree_hash))
+        $(format_tree_hashes(tree_hash))
 
         Registrator tree SHA: $(regtreesha)
         """
@@ -684,27 +689,58 @@ function register(
     return set_metadata!(regbr, status)
 end
 
+function format_tree_hashes(tree_hash::AbstractString)
+    return "Tree: $(string(tree_hash))"
+end
+
+function format_tree_hashes(tree_hash)
+    return join(("Tree ($key): $value" for (key, value) in pairs(tree_hash)), "\n")
+end
+
 """
     find_registered_version(pkg, registry_path)
 
 If the package and version specified by `pkg` exists in the registry
-at `registry_path`, return its tree hash. Otherwise return the empty
-string.
+at `registry_path` and has a SHA1 tree hash, return it. Otherwise
+return the empty string.
+
+This is a legacy function. New code and updates should use
+`find_registered_version_hashes`.
 """
 function find_registered_version(pkg::Project,
                                  registry_path::AbstractString)
+    hashes = find_registered_version_hashes(pkg::Project,
+                                            registry_path::AbstractString)
+    return get(hashes, "sha1", "")
+end
+"""
+    find_registered_version_hashes(pkg, registry_path)
+
+If the package and version specified by `pkg` exists in the registry
+at `registry_path`, return a dictionary containing pairs of hash
+algorithm names and corresponding tree hash values (as strings).
+Otherwise return an empty dictionary.
+"""
+function find_registered_version_hashes(pkg::Project,
+                                        registry_path::AbstractString)
+    hashes = Dict{String, String}()
     registry_file = joinpath(registry_path, "Registry.toml")
     registry_data = parse_registry(registry_file)
     # Cannot use find_package_in_registry since it may add paths in
     # the registry.
     if !haskey(registry_data.packages, string(pkg.uuid))
-        return ""
+        return hashes
     end
     package_data = registry_data.packages[string(pkg.uuid)]
     package_path = joinpath(registry_path, package_data["path"])
     _, versions_data = get_versions_file(package_path)
-    if !haskey(versions_data, string(pkg.version))
-        return ""
+    if haskey(versions_data, string(pkg.version))
+        for (key, value) in versions_data[string(pkg.version)]
+            if startswith(key, "git-tree-")
+                # chopprefix is nicer but requires Julia 1.8.
+                hashes[last(split(key, "git-tree-", limit = 2))] = value
+            end
+        end
     end
-    return versions_data[string(pkg.version)]["git-tree-sha1"]
+    return hashes
 end

--- a/test/regedit.jl
+++ b/test/regedit.jl
@@ -7,6 +7,7 @@ using RegistryTools: DEFAULT_REGISTRY_URL,
     gitcmd,
     register,
     find_registered_version,
+    find_registered_version_hashes,
     RegistryData
 import LibGit2
 using Pkg: TOML
@@ -281,31 +282,40 @@ end
 
 @testset "versions_file" begin
     import RegistryTools: get_versions_file, update_versions_file, check_versions!
-    mktempdir(@__DIR__) do temp_dir
-        pkg = Project(Dict("version" => "1.0.0"))
-        tree_hash = repeat("0", 40)
-        status = ReturnStatus()
+    tree_hashes = [repeat("0", 40),
+                   (; sha1 = repeat("0", 40), sha256 = repeat("0", 64))]
+    for tree_hash in tree_hashes
+        mktempdir(@__DIR__) do temp_dir
+            pkg = Project(Dict("version" => "1.0.0"))
+            status = ReturnStatus()
 
-        filename, data = get_versions_file(temp_dir)
-        @test filename == joinpath(temp_dir, "Versions.toml")
-        @test data isa Dict
-        @test isempty(data)
-        check_versions!(pkg, data, status)
-        # No previous version registered, this version is fine.
-        @test !haserror(status)
+            filename, data = get_versions_file(temp_dir)
+            @test filename == joinpath(temp_dir, "Versions.toml")
+            @test data isa Dict
+            @test isempty(data)
+            check_versions!(pkg, data, status)
+            # No previous version registered, this version is fine.
+            @test !haserror(status)
 
-        update_versions_file(pkg, filename, data, tree_hash)
+            update_versions_file(pkg, filename, data, tree_hash)
 
-        _, data = get_versions_file(temp_dir)
-        @test data isa Dict
-        @test collect(keys(data)) == ["1.0.0"]
-        @test data["1.0.0"] isa Dict
-        @test collect(keys(data["1.0.0"])) == ["git-tree-sha1"]
-        @test data["1.0.0"]["git-tree-sha1"] == tree_hash
+            _, data = get_versions_file(temp_dir)
+            @test data isa Dict
+            @test collect(keys(data)) == ["1.0.0"]
+            @test data["1.0.0"] isa Dict
+            if tree_hash isa String
+                @test collect(keys(data["1.0.0"])) == ["git-tree-sha1"]
+                @test data["1.0.0"]["git-tree-sha1"] == tree_hash
+            else
+                @test Set(keys(data["1.0.0"])) == Set(["git-tree-sha1", "git-tree-sha256"])
+                @test data["1.0.0"]["git-tree-sha1"] == tree_hash.sha1
+                @test data["1.0.0"]["git-tree-sha256"] == tree_hash.sha256
+            end
 
-        check_versions!(pkg, data, status)
-        # This version was just registered, should be a complaint now.
-        @test haserror(status)
+            check_versions!(pkg, data, status)
+            # This version was just registered, should be a complaint now.
+            @test haserror(status)
+        end
     end
 end
 
@@ -602,7 +612,7 @@ end
 
 # Helper function for the next testset.
 function create_and_populate_registry(registry_path, registry_name,
-                                      registry_uuid, package)
+                                      registry_uuid, package, tree_hash)
     # Create an empty registry.
     create_empty_registry(registry_path, registry_name, registry_uuid)
 
@@ -611,7 +621,6 @@ function create_and_populate_registry(registry_path, registry_name,
     project_file = joinpath(projects_path, "$(package).toml")
     pkg = Project(project_file)
     package_repo = "http://example.com/$(pkg.name).git"
-    tree_hash = repeat("0", 40)
     registry_deps_paths = String[]
     status = ReturnStatus()
     check_and_update_registry_files(pkg, package_repo, tree_hash,
@@ -635,30 +644,33 @@ end
 # version of one of the packages with a dependency to the other
 # package. The registration is pushed to a new branch via a file URL.
 @testset "register" begin
-    for pkg_f in [identity, Project]
+    tree_hashes = [repeat("0", 40),
+                   (; sha1 = repeat("0", 40), sha256 = repeat("0", 64))]
+    for pkg_f in [identity, Project], tree_hash in tree_hashes
         mktempdir(@__DIR__) do temp_dir
+            cache_dir = joinpath("temp_dir", "cache")
+            cache = RegistryTools.RegistryCache(cache_dir)
             registry1_path = joinpath(temp_dir, "Registry1")
             status = create_and_populate_registry(registry1_path, "Registry1",
                                                   "7e1d4fce-5fe6-405e-8bac-078d4138e9a2",
-                                                  "Example1")
+                                                  "Example1", tree_hash)
             @test !haserror(status)
 
             registry2_path = joinpath(@__DIR__, temp_dir, "Registry2")
             status = create_and_populate_registry(registry2_path, "Registry2",
                                                   "a5a8be26-c942-4674-beee-533a0e81ac1d",
-                                                  "Dep1")
+                                                  "Dep1", tree_hash)
             @test !haserror(status)
 
             projects_path = joinpath(@__DIR__, "project_files")
             project_file = joinpath(projects_path, "Example18.toml")
             pkg = pkg_f(project_file)
             package_repo = "http://example.com/Example.git"
-            tree_hash = repeat("0", 40)
             registry_repo = "file://$(registry1_path)"
             deps_repo = "file://$(registry2_path)"
             regbr = register(package_repo, pkg, tree_hash, registry = registry_repo,
                              registry_deps = [deps_repo], push = true,
-                             gitconfig = TEST_GITCONFIG)
+                             cache = cache, gitconfig = TEST_GITCONFIG)
             if haskey(regbr.metadata, "error") || haskey(regbr.metadata, "warning")
                 @info "" get(regbr.metadata, "error", nothing) get(regbr.metadata, "warning", nothing)
             end
@@ -667,13 +679,6 @@ end
             branches = readlines(`$git branch`)
             @test length(branches) == 2
         end
-
-        # Clean up the registry cache created by `register`.
-        rm(joinpath(@__DIR__, "registries", "7e1d4fce-5fe6-405e-8bac-078d4138e9a2"),
-           recursive = true)
-        rm(joinpath(@__DIR__, "registries", "a5a8be26-c942-4674-beee-533a0e81ac1d"),
-           recursive = true)
-        rm(joinpath(@__DIR__, "registries"))
     end
 end
 
@@ -690,15 +695,19 @@ end
         project_file = joinpath(projects_path, "Example1.toml")
         pkg = Project(project_file)
         @test find_registered_version(pkg, registry_path) == ""
+        @test find_registered_version_hashes(pkg, registry_path) == Dict()
         package_repo = string("http://example.com/$(pkg.name).git")
-        tree_hash = "7dd821daaae58ddf9fee53e00aa1aab33794d130"
+        tree_hash = (; sha1 = "7dd821daaae58ddf9fee53e00aa1aab33794d130",
+                     sha256 = "62f01487f2300b549c90804669856555e567ecc13fca092b1a4443f705630fd1")
         registry_deps_paths = String[]
         status = ReturnStatus()
         check_and_update_registry_files(pkg, package_repo, tree_hash,
                                         registry_path,
                                         registry_deps_paths, status)
 
-        @test find_registered_version(pkg, registry_path) == tree_hash
+        @test find_registered_version(pkg, registry_path) == tree_hash.sha1
+        @test find_registered_version_hashes(pkg, registry_path) ==
+            Dict("sha1" => tree_hash.sha1, "sha256" => tree_hash.sha256)
         project_file = joinpath(projects_path, "Example2.toml")
         pkg = Project(project_file)
         @test find_registered_version(pkg, registry_path) == ""
@@ -709,12 +718,15 @@ end
     pkg = Project(Dict("version" => "2.0.0"))
     # versions_file = "Versions.toml"
     version_data = Dict{String,Any}(
-         "1.0.0" => Dict("yanked"=>true,"git-tree-sha1"=>"b04b6c6bfd3a607aa1b85362b4854ef612137f3e"),
-         "3.0.0" => Dict("git-tree-sha1"=>"96429a372b5c4ad63fa9cbff6ba4178a85939705","foo"=>"bar")
+        "1.0.0" => Dict("yanked" => true,
+                        "git-tree-sha1" => "b04b6c6bfd3a607aa1b85362b4854ef612137f3e"),
+        "3.0.0" => Dict("git-tree-sha1" => "96429a372b5c4ad63fa9cbff6ba4178a85939705",
+                        "foo"=>"bar")
     )
-    tree_hash = "20cd0a2651eaf28c8a76c8d7fea4f1107f20174b"
+    tree_hash = (;sha1 = "20cd0a2651eaf28c8a76c8d7fea4f1107f20174b",
+                 sha256 = "0d77587419c4cfdd4f5ed7d2ce6db1b0a2786d4485edd19051c312762341eca6")
     mktemp() do path, io
-        RegistryTools.update_versions_file(pkg, path, version_data, tree_hash::AbstractString)
+        RegistryTools.update_versions_file(pkg, path, version_data, tree_hash)
         close(io)
         @test read(path, String) ==
         """
@@ -724,6 +736,7 @@ end
 
         ["2.0.0"]
         git-tree-sha1 = "20cd0a2651eaf28c8a76c8d7fea4f1107f20174b"
+        git-tree-sha256 = "0d77587419c4cfdd4f5ed7d2ce6db1b0a2786d4485edd19051c312762341eca6"
 
         ["3.0.0"]
         git-tree-sha1 = "96429a372b5c4ad63fa9cbff6ba4178a85939705"


### PR DESCRIPTION
Non-breaking alternative to #112.

Represent `tree_hash` as a named tuple, e.g. `(sha1 = "...", sha256 = "...")` and interpret a single string `x` as `(; sha1 = x)`. This generalizes to future new hash functions or removal of SHA1.

`find_registered_version` is complemented with `find_registered_version_hashes` to obtain all registered tree hashes.