### PR TITLE
Simplify get_registry_default_branch.

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -21,8 +21,15 @@ function path(cache::RegistryCache, registry_url::AbstractString)
     path(cache, cache.registries[registry_url])
 end
 
+# Cf. https://superuser.com/questions/1718677/find-the-default-branch-name-for-a-git-repository
+#
+# Avoid the user facing `git remote show origin` which might be
+# translated and produces much unneeded information.
 function get_registry_default_branch(git::Cmd)
-    readchomp(`$git rev-parse --abbrev-ref HEAD`)
+    lines = readlines(`$git ls-remote --symref origin HEAD`)
+    idx = findfirst(x -> startswith(x, "ref:"), lines)
+    idx === nothing && error("Failed to get default branch of registry")
+    basename(split(lines[idx])[2])
 end
 
 struct Project

--- a/src/types.jl
+++ b/src/types.jl
@@ -22,12 +22,7 @@ function path(cache::RegistryCache, registry_url::AbstractString)
 end
 
 function get_registry_default_branch(git::Cmd)
-    env = copy(ENV)
-    env["LANG"] = "en_US.UTF-8"
-    lines = collect(eachline(setenv(`$git remote show origin`, env)))
-    idx = findfirst(x -> occursin("HEAD branch", x), lines)
-    idx === nothing && error("Failed to get default branch of registry")
-    strip(split(lines[idx], ":")[2])
+    readchomp(`$git rev-parse --abbrev-ref HEAD`)
 end
 
 struct Project


### PR DESCRIPTION
Don't use a language sensitive user facing git command to try to dig out the branch name of `HEAD`. Use a plumbing command instead.

Fixes #115.